### PR TITLE
fix: update silverstripe-elemental-baseobject dependency to ^5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "dnadesign/silverstripe-elemental": "^5.0",
-        "dynamic/silverstripe-elemental-baseobject": "^4.0",
+        "dynamic/silverstripe-elemental-baseobject": "^5.0",
         "silverstripe/recipe-cms": "^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Issue

The `silverstripe-elemental-timeline` module cannot be installed in SilverStripe 5.x projects due to a dependency constraint conflict:

```
dynamic/silverstripe-elemental-timeline[dev-master, 3.0.0-alpha1, ..., 3.x-dev] require dynamic/silverstripe-elemental-baseobject ^4.0 -> found dynamic/silverstripe-elemental-baseobject[4.0.0-alpha1, 4.0.0-beta1, 4.0.0-beta2, 4.x-dev] but the package is fixed to 5.0.0 (lock file version)
```

## Solution

This PR updates the dependency constraint for `dynamic/silverstripe-elemental-baseobject` from `^4.0` to `^5.0` to ensure compatibility with SilverStripe 5.x projects.

## Changes

- Updated `dynamic/silverstripe-elemental-baseobject` dependency from `^4.0` to `^5.0` in composer.json
- Maintains compatibility with existing SilverStripe 5.x ecosystem

## Testing

After this change, the module can be successfully required in SilverStripe 5.x projects:

```bash
composer require dynamic/silverstripe-elemental-timeline
```

## Compatibility

- ✅ SilverStripe 5.x (dnadesign/silverstripe-elemental ^5.0)
- ✅ BaseObject 5.x (dynamic/silverstripe-elemental-baseobject ^5.0) 
- ✅ Recipe CMS 5.x (silverstripe/recipe-cms ^5.0)

This change ensures the timeline element works seamlessly in modern SilverStripe 5.x installations while maintaining all existing functionality.